### PR TITLE
feat: add timeout configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Traceback (most recent call last):
   File "/private/var/folders/w0/_tn54h2167bdhk6j_jglllxh0000gn/T/onefile_55983_1686498617_427518/requests/adapters.py", line 532, in send
 requests.exceptions.ReadTimeout: HTTPSConnectionPool(host='api.openai.com', port=443): Read timed out. (read timeout=20)
 ```
-    - Solution: You might need to **retry it** in a few time. If it still doesn't work, you can try to increase the timeout value in `src/commit_msg_generator.py`.
+    - Solution: You might need to **retry it** in a few time. If it still doesn't work, you can try to increase the timeout value in `~/.cg/config.json` file.
 
 ## License:
 GPLv3

--- a/src/commit_msg_generator.py
+++ b/src/commit_msg_generator.py
@@ -101,7 +101,8 @@ def get_score(config: Config, diff: str, msg: str) -> float:
             'Content-Type': 'application/json'
         },
         json=data,
-        timeout=20,)
+        timeout=config['timeout'],
+    )
 
     score = find_first_number(
         response.json()['choices'][0]['message']['content'])
@@ -164,7 +165,7 @@ def generate_commit_message(
             'https://api.openai.com/v1/chat/completions',
             headers=headers,
             json=data,
-            timeout=30,
+            timeout=config['timeout'],
         )
 
         # Response from OpenAI API like:

--- a/src/config_parser.py
+++ b/src/config_parser.py
@@ -43,6 +43,7 @@ the git commit message is suitable. You should only output a number
 from 0.0 to 10.0, without any reason.
 """
     },
+    "timeout": 30,
 }
 
 


### PR DESCRIPTION
The `timeout` configuration option has been added to the `config.json` file. This allows users to adjust the timeout value for API requests made by the commit message generator. The default value is 30 seconds.

The change was made in three files:
- README.md: updated instructions on how to increase timeout.
- src/commit_msg_generator.py: use config['timeout'] instead of hardcoded values.
- src/config_parser.py: added a new key-value pair 'timeout': 30, in default_config dictionary.