### PR TITLE
feat(config): add initial token if tokens list is empty (#8)

### DIFF
--- a/src/config_parser.py
+++ b/src/config_parser.py
@@ -84,7 +84,7 @@ class Config:
             os.makedirs(os.path.dirname(path), exist_ok=True)
             my_config = DEFAULT_CONFIG.copy()
             if my_config['tokens'] == ['']:
-                my_config['tokens'].append(init_first_token())
+                my_config['tokens'] = [init_first_token()]
 
             with open(path, 'w', encoding='utf-8') as file:
                 json.dump(my_config, file)


### PR DESCRIPTION
* feat: add timeout configuration option (#6)

The `timeout` configuration option has been added to the `config.json` file. This allows users to adjust the timeout value for API requests made by the commit message generator. The default value is 30 seconds.

The change was made in three files:
- README.md: updated instructions on how to increase timeout.
- src/commit_msg_generator.py: use config['timeout'] instead of hardcoded values.
- src/config_parser.py: added a new key-value pair 'timeout': 30, in default_config dictionary.

* fix(config): add initial token if tokens list is empty

If the `tokens` key in the configuration file was an empty list, this change adds an initial token to it. This ensures that there is always at least one valid token available for authentication purposes.

* feat(config): initialize tokens list with first token

The `config_parser.py` file has been updated to initialize the `tokens` list with the first token instead of appending it. This change ensures that there is always at least one token in the list, which is required for proper functionality. The method used to set this up was also modified slightly to ensure consistency and readability throughout the codebase.